### PR TITLE
グループ投稿機能のルーティング

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'messages#index' 
-  resources :messages, only: :index
   resources :users, only: [:edit, :update] 
+  resources :groups, only: [:new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end


### PR DESCRIPTION
#What
グループ投稿機能のルーティングを設定する。resourcesメソッドを用いて、
resources :groups, only: [:new, :create, :edit, :update] にresources :messages, only: [:index, :create]をネスト。

#Why
本機能は本アプリケーションにおいて根幹機能となるため。